### PR TITLE
Skip failed entries

### DIFF
--- a/ach/record_types/entry_detail.py
+++ b/ach/record_types/entry_detail.py
@@ -19,7 +19,7 @@ class EntryDetailRecordType(RecordType):
         'record_type_code': FieldDefinition('Record Type Code', IntegerFieldType, length=1, default=ENTRY_DETAIL_RECORD_TYPE_CODE),
         'transaction_code': FieldDefinition('Transaction Code', IntegerFieldType, length=2),
         'rdfi_routing': FieldDefinition('RDFI Routing Number', IntegerFieldType, length=9),
-        'rdfi_account_number': FieldDefinition('RDFI Account Number', AlphaNumFieldType, length=17),
+        'rdfi_account_number': FieldDefinition('RDFI Account Number', AlphaNumFieldType, length=17, auto_correct_input=False),
         'amount': FieldDefinition('Transaction Amount Expressed As Cents', IntegerFieldType, length=10),
         'individual_identification_number': FieldDefinition('Individual Identification Number (Alphanumeric)', AlphaNumFieldType, length=15, required=False),
         'individual_name': FieldDefinition('Individual Name', AlphaNumFieldType, length=22),

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,17 @@ setup(
     name='ach-file',
     author='Molly Gouletas',
     author_email='molly.gouletas@gmail.com',
-    version='0.1.4.beta',
+    version='0.1.5.beta',
     packages=find_packages(exclude=['tests']),
     url='https://github.com/freemish/ach-file',
     license='MIT License',
     description='Highly configurable and permissive library to generate ACH files',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
Rather than erroring out on a whole file for a single failed entry, skip failed entries.

This changes the behavior of the account number field to stop auto-removing disallowed characters; instead, it errors out entirely.

This does not account for other possible transaction codes in an entry; if one is passed that is not recognized in the TransactionCode enum, the whole file will still fail. This is to be accounted for in a future fix.