### PR TITLE
Add missing company identification number in ACH Header

### DIFF
--- a/ach/constants.py
+++ b/ach/constants.py
@@ -36,11 +36,11 @@ class TransactionCode(enum.IntEnum):
 
     @classmethod
     def _missing_(cls, value):
-        return cls._create_pseudo_member_(value)
+        return cls._create_pseudo_member(value)
 
     # pylint: disable=attribute-defined-outside-init
     @classmethod
-    def _create_pseudo_member_(cls, value):
+    def _create_pseudo_member(cls, value):
         pseudo_member = cls._value2member_map_.get(value, None)
         if pseudo_member is None:
             new_member = int.__new__(cls, value)

--- a/ach/files/file_builder.py
+++ b/ach/files/file_builder.py
@@ -22,7 +22,7 @@ class NoBatchForTransactionError(Exception):
 class ACHFileBuilder:
     """Builds an ACHFileContents object."""
 
-    def __init__(self, **file_settings):
+    def __init__(self, odfi_identification: str, **file_settings: Any) -> None:
         """
         Accepts a dict of file settings.
         Run cls.get_file_setting_fields to see all key options.
@@ -31,26 +31,25 @@ class ACHFileBuilder:
 
             settings_dict = {
                 'destination_routing': '012345678',
-                'origin_routing': '102345678',
                 'destination_name': 'YOUR BANK',
+                'company_identification': 'Company Identification Number',
                 'origin_name': 'YOUR FINANCIAL INSTITUTION',
                 'file_id_modifier': 'B',
             }
-            ACHFileBuilder(**settings_dict)
+            ACHFileBuilder(odfi_identification, **settings_dict)
 
             ACHFileBuilder(
+                odfi_identification='10234567',
                 destination_routing='012345678',
-                origin_routing='102345678',
                 destination_name='YOUR BANK',
-                origin_name='YOUR FINANCIAL INSTITUTION',
+                origin_name='YOUR FINANCIAL INSTITUTION'
+                company_identification='Company Identification Number',
             )
         """
         self.ach_file_contents: ACHFileContents = ACHFileContents(
             FileHeaderRecordType(**file_settings)
         )
-        self.default_odfi_identification: str = file_settings.get(
-            "origin_routing", ""
-        ).lstrip()[:8]
+        self.default_odfi_identification = odfi_identification
 
     def render(self, line_break: str = "\n", end: str = "\n") -> str:
         """Renders ACH flat file contents as a string."""

--- a/ach/record_types/file_header.py
+++ b/ach/record_types/file_header.py
@@ -45,11 +45,8 @@ class FileHeaderRecordType(RecordType):
             length=10,
             auto_correct_input=True,
         ),
-        "origin_routing": FieldDefinition(
-            "Immediate Origin Routing",
-            BlankPaddedRoutingNumberFieldType,
-            length=10,
-            auto_correct_input=True,
+        "company_identification": FieldDefinition(
+            "Company Identification Number", IntegerFieldType, length=10
         ),
         "file_creation_date": FieldDefinition(
             "File Creation Date",
@@ -93,14 +90,14 @@ class FileHeaderRecordType(RecordType):
     def __init__(
         self,
         destination_routing: str,
-        origin_routing: str,
+        company_identification: str,
         destination_name: str,
         origin_name: str,
         **kwargs
     ):
         self.field_definition_dict = self.field_definition_dict
         kwargs["destination_routing"] = destination_routing
-        kwargs["origin_routing"] = origin_routing
+        kwargs["company_identification"] = company_identification
         kwargs["destination_name"] = destination_name
         kwargs["origin_name"] = origin_name
         super().__init__(**kwargs)


### PR DESCRIPTION
What this PR is for:

* Add missing company identification number in ACH Header
   - In the header, the origin routing is added and also used in odfi_identification but in the header, it should contain  the company ID after the destination routing according to this [doc](https://help.loanpro.io/article/opq9bhnwen-how-nacha-files-work#:~:text=NACHA%20file%20to.-,Company%20ID,-1123456789)
* Fix Error message _sunder_ names, such as '_create_pseudo_member_', are reserved for future Enum use

Next Steps:
* update test cases
* update documentation