### PR TITLE
Use origin_id instead of  origin_routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ from ach.constants import AutoDateInput, BatchStandardEntryClassCode, Transactio
 
 b = ACHFileBuilder(
     destination_routing='012345678',
-    origin_routing='102345678',
+    origin_id='1234567890', #your company ID in this field
     destination_name='YOUR BANK',
     origin_name='YOUR FINANCIAL INSTITUTION',
 )
@@ -81,7 +81,7 @@ Below are tables describing all of the valid input arguments for the callables i
 |record_type_code|IntegerFieldType|True|1|
 |priority_code|IntegerFieldType|True|1|
 |destination_routing|BlankPaddedRoutingNumberFieldType|True|None|
-|origin_routing|BlankPaddedRoutingNumberFieldType|True|None|
+|origin_id|AlphaNumFieldType|True|None|
 |file_creation_date|DateFieldType|True|"NOW"|
 |file_creation_time|TimeFieldType|False|None|
 |file_id_modifier|AlphaNumFieldType|True|"A"|
@@ -100,7 +100,7 @@ Below are tables describing all of the valid input arguments for the callables i
 |service_class_code|IntegerFieldType|True|200|
 |company_name|AlphaNumFieldType|True|None|
 |company_discretionary_data|AlphaNumFieldType|False|None|
-|company_identification|IntegerFieldType|True|None|
+|company_identification|AlphaNumFieldType|True|None|
 |standard_entry_class_code|AlphaNumFieldType|True|"PPD"|
 |company_entry_description|AlphaNumFieldType|True|None|
 |company_descriptive_date|DateFieldType|False|None|

--- a/ach/files/file_builder.py
+++ b/ach/files/file_builder.py
@@ -39,7 +39,7 @@ class ACHFileBuilder:
 
             settings_dict = {
                 'destination_routing': '012345678',
-                'origin_routing': '102345678',
+                'origin_id': '102345678',
                 'destination_name': 'YOUR BANK',
                 'origin_name': 'YOUR FINANCIAL INSTITUTION',
                 'file_id_modifier': 'B',
@@ -48,7 +48,7 @@ class ACHFileBuilder:
 
             ACHFileBuilder(
                 destination_routing='012345678',
-                origin_routing='102345678',
+                origin_id='102345678',
                 destination_name='YOUR BANK',
                 origin_name='YOUR FINANCIAL INSTITUTION',
             )

--- a/ach/files/file_builder.py
+++ b/ach/files/file_builder.py
@@ -57,7 +57,7 @@ class ACHFileBuilder:
             self.file_header_record_type_class(**file_settings)
         )
         self.default_odfi_identification: str = file_settings.get(
-            "origin_routing", ""
+            "destination_routing", ""
         ).lstrip()[:8]
 
     def render(self, line_break: str = "\n", end: str = "\n") -> str:

--- a/ach/record_types/batch_control.py
+++ b/ach/record_types/batch_control.py
@@ -35,7 +35,7 @@ class BatchControlRecordType(RecordType):
             "Total Credit Amount", IntegerFieldType, length=12
         ),
         "company_identification": FieldDefinition(
-            "Company Identification", IntegerFieldType, length=10
+            "Company Identification", AlphaNumFieldType, length=10
         ),
         "message_authentication_code": FieldDefinition(
             "Message Authentication Code", AlphaNumFieldType, length=19, required=False

--- a/ach/record_types/batch_header.py
+++ b/ach/record_types/batch_header.py
@@ -40,7 +40,7 @@ class BatchHeaderRecordType(RecordType):
             "Company Discretionary Data", AlphaNumFieldType, length=20, required=False
         ),
         "company_identification": FieldDefinition(
-            "Company Identification Number", IntegerFieldType, length=10
+            "Company Identification Number", AlphaNumFieldType, length=10
         ),
         "standard_entry_class_code": FieldDefinition(
             "Standard Entry Class Code",

--- a/ach/record_types/file_header.py
+++ b/ach/record_types/file_header.py
@@ -43,13 +43,11 @@ class FileHeaderRecordType(RecordType):
             "Immediate Destination Routing",
             BlankPaddedRoutingNumberFieldType,
             length=10,
-            auto_correct_input=True,
         ),
-        "origin_routing": FieldDefinition(
-            "Immediate Origin Routing",
-            BlankPaddedRoutingNumberFieldType,
+        "origin_id": FieldDefinition(
+            "Immediate Origin Routing or Company ID",
+           AlphaNumFieldType,
             length=10,
-            auto_correct_input=True,
         ),
         "file_creation_date": FieldDefinition(
             "File Creation Date",
@@ -91,16 +89,16 @@ class FileHeaderRecordType(RecordType):
     }
 
     def __init__(
-        self,
-        destination_routing: str,
-        origin_routing: str,
-        destination_name: str,
-        origin_name: str,
-        **kwargs
+            self,
+            destination_routing: str,
+            origin_id: str,
+            destination_name: str,
+            origin_name: str,
+            **kwargs
     ):
         self.field_definition_dict = self.field_definition_dict
         kwargs["destination_routing"] = destination_routing
-        kwargs["origin_routing"] = origin_routing
+        kwargs["origin_id"] = origin_id
         kwargs["destination_name"] = destination_name
         kwargs["origin_name"] = origin_name
         super().__init__(**kwargs)

--- a/tests/test_ach_file_builder.py
+++ b/tests/test_ach_file_builder.py
@@ -24,7 +24,7 @@ class TestDisplayRequiredKeys(TestCase):
     def test_ach_file_builder_required_file_header_keys(self):
         test_required_keys = [
             "destination_routing",
-            "origin_routing",
+            "origin_id",
             "destination_name",
             "origin_name",
         ]
@@ -40,7 +40,7 @@ class TestDisplayRequiredKeys(TestCase):
             "record_type_code",
             "priority_code",
             "destination_routing",
-            "origin_routing",
+            "origin_id",
             "file_creation_date",
             "file_creation_time",
             "file_id_modifier",
@@ -176,7 +176,7 @@ class TestACHFileBuilder(TestCase):
     def test_ach_file_builder(self):
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="102345678",
+            origin_id="102345678",
             destination_name="YOUR BANK",
             origin_name="YOUR FINANCIAL INSTITUTION",
         )
@@ -232,7 +232,7 @@ class TestACHFileBuilder(TestCase):
     def test_ach_file_builder_multiple_batches(self):
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="102345678",
+            origin_id="102345678",
             destination_name="YOUR BANK",
             origin_name="YOUR FINANCIAL INSTITUTION",
         )
@@ -362,7 +362,7 @@ class TestACHFileBuilder(TestCase):
     def test_add_transaction_before_batch(self):
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="102345678",
+            origin_id="102345678",
             destination_name="YOUR BANK",
             origin_name="YOUR FINANCIAL INSTITUTION",
         )
@@ -419,7 +419,7 @@ class TestACHFileBuilder(TestCase):
     def test_add_transaction_before_batch_raise_exc_false(self):
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="102345678",
+            origin_id="102345678",
             destination_name="YOUR BANK",
             origin_name="YOUR FINANCIAL INSTITUTION",
         )
@@ -477,7 +477,7 @@ class TestACHFileBuilder(TestCase):
     def test_ach_file_builder_result_passes_parser_skips_entries(self):
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="102345678",
+            origin_id="102345678",
             destination_name="YOUR BANK",
             origin_name="YOUR FINANCIAL INSTITUTION",
         )
@@ -536,7 +536,7 @@ class TestACHFileBuilder(TestCase):
     def test_add_transaction_to_nonexistent_batch(self):
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="102345678",
+            origin_id="102345678",
             destination_name="YOUR BANK",
             origin_name="YOUR FINANCIAL INSTITUTION",
         )
@@ -603,11 +603,11 @@ class TestACHFileBuilder(TestCase):
     def test_ach_file_builder_for_custom_field_definition(self):
         """Tests to ensure use case for 10-digit file header odfi identification field is met."""
         self.ach_file_builder_class.file_header_record_type_class.field_definition_dict[
-            "origin_routing"
+            "origin_id"
         ].field_type = AlphaNumFieldType
         b = self.ach_file_builder_class(
             destination_routing="012345678",
-            origin_routing="1234567890",
+            origin_id="1234567890",
             destination_name="YOUR BANK",
             origin_name="YOUR COMPANY",
         )
@@ -660,5 +660,5 @@ class TestACHFileBuilder(TestCase):
             b.ach_file_contents.render_json_dict(), ach_file_contents.render_json_dict()
         )
         self.ach_file_builder_class.file_header_record_type_class.field_definition_dict[
-            "origin_routing"
+            "origin_id"
         ].field_type = BlankPaddedRoutingNumberFieldType

--- a/tests/test_ach_file_structure.py
+++ b/tests/test_ach_file_structure.py
@@ -32,7 +32,7 @@ class TestACHFileContents(TestCase):
         file_contents = ACHFileContents(
             FileHeaderRecordType(
                 destination_routing=123456780,
-                origin_routing=123456780,
+                origin_id=123456780,
                 destination_name="YOUR BANK",
                 origin_name="YOUR COMPANY",
                 file_creation_date="140902",
@@ -96,7 +96,7 @@ class TestACHFileContents(TestCase):
         ach_file_contents = ACHFileContentsParser(test_file).process_ach_file_contents()
         new_file_header = FileHeaderRecordType(
             destination_routing=123456780,
-            origin_routing=123456780,
+            origin_id=123456780,
             destination_name="YOUR BANK",
             origin_name="YOUR COMPANY",
             file_creation_date="140902",

--- a/tests/test_record_types.py
+++ b/tests/test_record_types.py
@@ -154,7 +154,7 @@ class TestBatchHeaderRecordType(TestCase):
         self.assertEqual(len(record_line), 94)
         self.assertEqual(
             record_line,
-            "5200Teeniest Fintech                    0000000123PPDPayday          221023   1012345670000002",
+            "5200Teeniest Fintech                    123       PPDPayday          221023   1012345670000002",
         )
 
 
@@ -214,7 +214,7 @@ class TestBatchControlRecordType(TestCase):
         self.assertEqual(len(record_line), 94)
         self.assertEqual(
             record_line,
-            "820000000200000005430000000001000000000000000000000123                         123456780000001",
+            "82000000020000000543000000000100000000000000123                                123456780000001",
         )
 
 


### PR DESCRIPTION
According to this [documentation](https://achdevguide.nacha.org/ach-file-details#:~:text=4-,Immediate%20Origin,-14%2D23) of the Nacha file

Immediate Origin: The nine-digit routing transit number of the institution sending (originating) the ACH file, preceded by a blank. **(Often your ODFI will have you insert your `company ID` in this field.)`**

What this PR is will change:
* use `origin_id` instead of `origin_routing` with type `AlphaNumFieldType`
* change `copmany_identification`  type in the batch header and control  to `AlphaNumFieldType`
* use `destenation_routing` to set `default_odfi_identification`, this change is in a separate [PR](https://github.com/freemish/ach-file/pull/22).

Tests: all pass

Note: this PR is **breaking change** 